### PR TITLE
[BUG] Update footer links on mobile

### DIFF
--- a/src/_includes/partials/footer.html
+++ b/src/_includes/partials/footer.html
@@ -36,16 +36,16 @@
             <div class="flex-1">
                 <p class="text-white md:mb-6">Resources</p>
                 <ul class="list-reset mb-6">
-                    <li class="mt-2 inline-block mr-2 md:block md:mr-0">
+                    <li class="mt-2 mr-2 block md:mr-0">
                         <a href="#" class="no-underline text-gray-400 hover:text-blue-500">About Us</a>
                     </li>
-                    <li class="mt-2 inline-block mr-2 md:block md:mr-0">
+                    <li class="mt-2 mr-2 block md:mr-0">
                         <a href="#" class="no-underline text-gray-400 hover:text-blue-500">Blog</a>
                     </li>
-                    <li class="mt-2 inline-block mr-2 md:block md:mr-0">
+                    <li class="mt-2 mr-2 block md:mr-0">
                         <a href="#" class="no-underline text-gray-400 hover:text-blue-500">Contact</a>
                     </li>
-                    <li class="mt-2 inline-block mr-2 md:block md:mr-0">
+                    <li class="mt-2 mr-2 block md:mr-0">
                         <a href="#" class="no-underline text-gray-400 hover:text-blue-500">FAQ</a>
                     </li>
                 </ul>
@@ -53,16 +53,16 @@
             <div class="flex-1">
                 <p class="text-white md:mb-6">Legal Stuff</p>
                 <ul class="list-reset mb-6">
-                    <li class="mt-2 inline-block mr-2 md:block md:mr-0">
+                    <li class="mt-2 mr-2 md:block md:mr-0">
                         <a href="#" class="no-underline text-gray-400 hover:text-blue-500">Disclaimer</a>
                     </li>
-                    <li class="mt-2 inline-block mr-2 md:block md:mr-0">
+                    <li class="mt-2 mr-2 block md:mr-0">
                         <a href="#" class="no-underline text-gray-400 hover:text-blue-500">Financing</a>
                     </li>
-                    <li class="mt-2 inline-block mr-2 md:block md:mr-0">
+                    <li class="mt-2 mr-2 block md:mr-0">
                         <a href="#" class="no-underline text-gray-400 hover:text-blue-500">Privacy Policy</a>
                     </li>
-                    <li class="mt-2 inline-block mr-2 md:block md:mr-0">
+                    <li class="mt-2 mr-2 block md:mr-0">
                         <a href="#" class="no-underline text-gray-400 hover:text-blue-500">Terms of Service</a>
                     </li>
                 </ul>


### PR DESCRIPTION
## Related Issue [#70 ](https://github.com/web3community/web3community.github.io/issues/70)

- The footer links had the incorrect class name on them

Closes: #70  <!-- issue number that will be closed through this PR -->

### Describe the changes you've made
The list items under Resources, Legal stuff, and Contact were set to `inline-block` on mobile making them sit inline with each other. I removed that class name and updated the block class name from `md:block` to `block` since we want them to always display as `block`.
<!-- Give a clear description of what modifications you have made -->

## Type of change

What sort of change have you made:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
I have tested this locally on my machine in 3 different browsers and devices.
<!-- Describe how have you verified the changes made -->

## Checklist
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly wherever it was hard to understand.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if applicable)

 Original           | Updated
 :--------------------: |:--------------------:
 
<img width="351" alt="Screen Shot 2021-10-04 at 8 26 10 PM" src="https://user-images.githubusercontent.com/12242330/135950889-9a24445e-c8a2-4744-a4c8-fa7baffa5193.png">
 | 
<img width="172" alt="Screen Shot 2021-10-04 at 9 28 14 PM" src="https://user-images.githubusercontent.com/12242330/135950908-398c4962-0001-4452-a4a6-34461d749898.png">
|
 
## Code of Conduct

- [x] I agree to follow this project's Code of Conduct
 
